### PR TITLE
Switch tasks using stack pointers

### DIFF
--- a/arch/x86_64/cpu/CMakeLists.txt
+++ b/arch/x86_64/cpu/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(quark.kernel
     ${CMAKE_CURRENT_SOURCE_DIR}/trampoline.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/signal.asm
     ${CMAKE_CURRENT_SOURCE_DIR}/tables.asm
+    ${CMAKE_CURRENT_SOURCE_DIR}/task.asm
 )
 
 if (ARCH STREQUAL "x86_64")

--- a/arch/x86_64/cpu/idt.cc
+++ b/arch/x86_64/cpu/idt.cc
@@ -46,7 +46,6 @@ extern "C" void isr28(void);
 extern "C" void isr29(void);
 extern "C" void isr30(void);
 extern "C" void isr31(void);
-extern "C" void isr129(void);
 extern "C" void irq0(void);
 extern "C" void irq1(void);
 extern "C" void irq2(void);
@@ -129,10 +128,6 @@ void init()
     idt::set_entry(&entries[45], reinterpret_cast<addr_t>(irq13), 0x08, 0x8E);
     idt::set_entry(&entries[46], reinterpret_cast<addr_t>(irq14), 0x08, 0x8E);
     idt::set_entry(&entries[47], reinterpret_cast<addr_t>(irq15), 0x08, 0x8E);
-
-    // Yield vector
-    idt::set_entry(&entries[0x81], reinterpret_cast<addr_t>(isr129), 0x08,
-                   0x8E);
 
     idt::idt_load(reinterpret_cast<addr_t>(&descriptor));
 }

--- a/arch/x86_64/cpu/syscall.asm
+++ b/arch/x86_64/cpu/syscall.asm
@@ -2,6 +2,7 @@
 
 extern syscall_trampoline
 
+global syscall_return
 global syscall_sysret_wrapper
 syscall_sysret_wrapper:
     swapgs              ; Thread struct is saved in KernelGSBase, swap it into GS
@@ -45,6 +46,7 @@ syscall_sysret_wrapper:
     mov rdi, rsp
     call syscall_trampoline
 
+syscall_return:
     ; There isn't really a reason for system calls to be modifying FS and GS
     pop r15
     pop r15

--- a/arch/x86_64/cpu/syscall.asm
+++ b/arch/x86_64/cpu/syscall.asm
@@ -7,7 +7,7 @@ global syscall_sysret_wrapper
 syscall_sysret_wrapper:
     swapgs              ; Thread struct is saved in KernelGSBase, swap it into GS
     mov [gs:80], rsp    ; Save user RSP into thread->tcontext.rsp
-    mov rsp, [gs:184]   ; Load kernel RSP from thread->kernel_stack.
+    mov rsp, [gs:192]   ; Load kernel RSP from thread->kernel_stack_base
 
     ; Build a simulated interrupt frame
     push qword 0x1B ; SS

--- a/arch/x86_64/cpu/task.asm
+++ b/arch/x86_64/cpu/task.asm
@@ -1,0 +1,27 @@
+%include "common.inc"
+
+; void do_task_switch(addr_t* old_stack, addr_t* new_stack, addr_t cr3);
+; rdi = old stack, rsi = new stack, rdx = cr3
+global do_task_switch
+do_task_switch:
+    pushfq
+    push rbp
+    push rbx
+    push r12
+    push r13
+    push r14
+    push r15
+
+    mov [rdi], rsp
+    mov rsp, [rsi]
+
+    mov cr3, rdx
+
+    pop r15
+    pop r14
+    pop r13
+    pop r12
+    pop rbx
+    pop rbp
+    popf
+    ret

--- a/arch/x86_64/cpu/task.asm
+++ b/arch/x86_64/cpu/task.asm
@@ -1,7 +1,7 @@
 %include "common.inc"
 
-; void do_task_switch(addr_t* old_stack, addr_t* new_stack, addr_t cr3);
-; rdi = old stack, rsi = new stack, rdx = cr3
+; void do_task_switch(addr_t* old_stack, addr_t* new_stack);
+; rdi = old stack, rsi = new stack
 global do_task_switch
 do_task_switch:
     pushfq
@@ -14,8 +14,6 @@ do_task_switch:
 
     mov [rdi], rsp
     mov rsp, [rsi]
-
-    mov cr3, rdx
 
     pop r15
     pop r14

--- a/arch/x86_64/proc/CMakeLists.txt
+++ b/arch/x86_64/proc/CMakeLists.txt
@@ -1,6 +1,5 @@
 target_sources(quark.kernel
     PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/sched.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/signal.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/thread.cc
 )

--- a/arch/x86_64/proc/sched.cc
+++ b/arch/x86_64/proc/sched.cc
@@ -1,9 +1,0 @@
-#include <proc/sched.h>
-
-namespace scheduler
-{
-void yield()
-{
-    __asm__ __volatile__("int $0x81");
-}
-} // namespace scheduler

--- a/arch/x86_64/proc/thread.cc
+++ b/arch/x86_64/proc/thread.cc
@@ -127,13 +127,15 @@ void thread::switch_thread(thread* next)
                    next->parent->get_address_space());
 }
 
-thread* create_kernel_thread(process* p, void (*entry_point)())
+thread* create_kernel_thread(process* p, void (*entry_point)(void*), void* data)
 {
     thread* kthread = p->create_thread();
-    addr_t* stack   = reinterpret_cast<addr_t*>(kthread->get_stack());
-    stack[-1]       = (addr_t)entry_point;             // RIP
-    stack[-2]       = 0x200;                           // RFLAGS
-    stack[-3]       = reinterpret_cast<addr_t>(stack); // RBP
+    struct thread_context ctx;
+    libcxx::memset(&ctx, 0, sizeof(ctx));
+    addr_t* stack = reinterpret_cast<addr_t*>(kthread->get_stack());
+    stack[-1]     = (addr_t)entry_point;             // RIP
+    stack[-2]     = 0x200;                           // RFLAGS
+    stack[-3]     = reinterpret_cast<addr_t>(stack); // RBP
     kthread->set_stack(reinterpret_cast<addr_t>(stack) - 64);
     return kthread;
 }

--- a/arch/x86_64/proc/thread.cc
+++ b/arch/x86_64/proc/thread.cc
@@ -127,15 +127,13 @@ void thread::switch_thread(thread* next)
                    next->parent->get_address_space());
 }
 
-thread* create_kernel_thread(process* p, void (*entry_point)(void*), void* data)
+thread* create_kernel_thread(process* p, void (*entry_point)())
 {
     thread* kthread = p->create_thread();
-    struct thread_context ctx;
-    libcxx::memset(&ctx, 0, sizeof(ctx));
-    addr_t* stack = reinterpret_cast<addr_t*>(kthread->get_stack());
-    stack[-1]     = (addr_t)entry_point;             // RIP
-    stack[-2]     = 0x200;                           // RFLAGS
-    stack[-3]     = reinterpret_cast<addr_t>(stack); // RBP
+    addr_t* stack   = reinterpret_cast<addr_t*>(kthread->get_stack());
+    stack[-1]       = (addr_t)entry_point;             // RIP
+    stack[-2]       = 0x200;                           // RFLAGS
+    stack[-3]       = reinterpret_cast<addr_t>(stack); // RBP
     kthread->set_stack(reinterpret_cast<addr_t>(stack) - 64);
     return kthread;
 }

--- a/arch/x86_64/proc/thread.cc
+++ b/arch/x86_64/proc/thread.cc
@@ -15,11 +15,6 @@ namespace
 {
 extern "C" void syscall_return();
 
-addr_t get_stack()
-{
-    return cpu::x86_64::TSS::get_stack();
-}
-
 void set_thread_base(addr_t base)
 {
     cpu::x86_64::wrmsr(cpu::x86_64::msr_kernel_gs_base, base);
@@ -133,7 +128,7 @@ extern "C" void do_task_switch(addr_t* old_stack, addr_t* new_stack);
 
 void thread::switch_thread(thread* next)
 {
-    cpu::x86_64::TSS::set_stack(next->tcb.kernel_stack);
+    cpu::x86_64::TSS::set_stack(next->kernel_stack_base);
     set_thread_base(reinterpret_cast<addr_t>(&next->tcb));
     do_task_switch(&this->tcb.kernel_stack, &next->tcb.kernel_stack);
 }

--- a/arch/x86_64/proc/thread.cc
+++ b/arch/x86_64/proc/thread.cc
@@ -13,11 +13,6 @@
 
 namespace
 {
-void set_stack(addr_t stack)
-{
-    cpu::x86_64::TSS::set_stack(stack);
-}
-
 addr_t get_stack()
 {
     return cpu::x86_64::TSS::get_stack();
@@ -123,6 +118,8 @@ extern "C" void do_task_switch(addr_t* old_stack, addr_t* new_stack,
 
 void thread::switch_thread(thread* next)
 {
+    cpu::x86_64::TSS::set_stack(next->tcb.kernel_stack);
+    set_thread_base(reinterpret_cast<addr_t>(&next->tcb));
     do_task_switch(&this->tcb.kernel_stack, &next->tcb.kernel_stack,
                    next->parent->get_address_space());
 }

--- a/arch/x86_64/proc/thread.cc
+++ b/arch/x86_64/proc/thread.cc
@@ -147,6 +147,7 @@ thread* create_kernel_thread(process* p, void (*entry_point)(void*), void* data)
     stack[-1]     = reinterpret_cast<addr_t>(entry_point); // RIP
     stack[-2]     = 0x200;                                 // RFLAGS
     stack[-3]     = reinterpret_cast<addr_t>(stack);       // RBP
+    stack[-4] = stack[-5] = stack[-6] = stack[-7] = stack[-8] = 0;
     kthread->set_stack(reinterpret_cast<addr_t>(stack) - 64);
     return kthread;
 }

--- a/arch/x86_64/proc/thread.cc
+++ b/arch/x86_64/proc/thread.cc
@@ -128,7 +128,7 @@ extern "C" void do_task_switch(addr_t* old_stack, addr_t* new_stack);
 
 void thread::switch_thread(thread* next)
 {
-    cpu::x86_64::TSS::set_stack(next->kernel_stack_base);
+    cpu::x86_64::TSS::set_stack(next->tcb.kernel_stack_base);
     set_thread_base(reinterpret_cast<addr_t>(&next->tcb));
     do_task_switch(&this->tcb.kernel_stack, &next->tcb.kernel_stack);
 }

--- a/arch/x86_64/proc/thread.cc
+++ b/arch/x86_64/proc/thread.cc
@@ -104,7 +104,6 @@ void thread::fork_init()
     // Time to hack the stack
     stack[-1] = reinterpret_cast<addr_t>(syscall_return); // RIP
     stack[-2] = 0x200;                                    // RFLAGS
-    stack[-3] = reinterpret_cast<addr_t>(stack);          // RBP
     this->tcb.kernel_stack -= 64;
 }
 

--- a/arch/x86_64/proc/thread.cc
+++ b/arch/x86_64/proc/thread.cc
@@ -113,15 +113,13 @@ void thread::load_state(interrupt_context* ctx)
     set_thread_base(reinterpret_cast<addr_t>(&this->tcb));
 }
 
-extern "C" void do_task_switch(addr_t* old_stack, addr_t* new_stack,
-                               addr_t cr3);
+extern "C" void do_task_switch(addr_t* old_stack, addr_t* new_stack);
 
 void thread::switch_thread(thread* next)
 {
     cpu::x86_64::TSS::set_stack(next->tcb.kernel_stack);
     set_thread_base(reinterpret_cast<addr_t>(&next->tcb));
-    do_task_switch(&this->tcb.kernel_stack, &next->tcb.kernel_stack,
-                   next->parent->get_address_space());
+    do_task_switch(&this->tcb.kernel_stack, &next->tcb.kernel_stack);
 }
 
 thread* create_kernel_thread(process* p, void (*entry_point)(void*), void* data)

--- a/cpu/interrupt.cc
+++ b/cpu/interrupt.cc
@@ -51,6 +51,11 @@ void dispatch(int int_no, struct interrupt_context* ctx)
                                                       false);
             scheduler::switch_next();
         }
+        if (scheduler::online()) {
+            if (scheduler::get_current_thread()->is_signal_pending()) {
+                scheduler::get_current_thread()->handle_signal(ctx);
+            }
+        }
     }
 }
 

--- a/cpu/interrupt.cc
+++ b/cpu/interrupt.cc
@@ -45,6 +45,12 @@ void dispatch(int int_no, struct interrupt_context* ctx)
     }
     if (!is_exception(int_no)) {
         irqchip::ack(interrupt::interrupt_to_irq(int_no));
+        if (scheduler::online() && scheduler::get_current_thread()->get_flag(
+                                       thread_flag::RESCHEDULE)) {
+            scheduler::get_current_thread()->set_flag(thread_flag::RESCHEDULE,
+                                                      false);
+            scheduler::switch_next(ctx);
+        }
     }
 }
 

--- a/cpu/interrupt.cc
+++ b/cpu/interrupt.cc
@@ -51,10 +51,10 @@ void dispatch(int int_no, struct interrupt_context* ctx)
                                                       false);
             scheduler::switch_next();
         }
-        if (scheduler::online()) {
-            if (scheduler::get_current_thread()->is_signal_pending()) {
-                scheduler::get_current_thread()->handle_signal(ctx);
-            }
+    }
+    if (scheduler::online()) {
+        if (scheduler::get_current_thread()->is_signal_pending()) {
+            scheduler::get_current_thread()->handle_signal(ctx);
         }
     }
 }

--- a/cpu/interrupt.cc
+++ b/cpu/interrupt.cc
@@ -49,7 +49,7 @@ void dispatch(int int_no, struct interrupt_context* ctx)
                                        thread_flag::RESCHEDULE)) {
             scheduler::get_current_thread()->set_flag(thread_flag::RESCHEDULE,
                                                       false);
-            scheduler::switch_next(ctx);
+            scheduler::switch_next();
         }
     }
 }

--- a/fs/poll.cc
+++ b/fs/poll.cc
@@ -75,7 +75,7 @@ int poll_table::poll(time_t timeout)
         if (found)
             break;
         scheduler::remove(scheduler::get_current_thread());
-        scheduler::yield();
+        scheduler::switch_next();
         // TODO: Check if a signal is the reason why we woke
     }
     // Now let's clean up :)

--- a/include/proc/sched.h
+++ b/include/proc/sched.h
@@ -13,7 +13,7 @@ bool remove(thread* thread);
 
 void init();
 void late_init();
-void switch_next(struct interrupt_context* ctx);
+void switch_next();
 void yield();
 
 process* get_current_process();

--- a/include/proc/sched.h
+++ b/include/proc/sched.h
@@ -14,7 +14,6 @@ bool remove(thread* thread);
 void init();
 void late_init();
 void switch_next();
-void yield();
 
 process* get_current_process();
 thread* get_current_thread();

--- a/include/proc/thread.h
+++ b/include/proc/thread.h
@@ -40,6 +40,8 @@ public:
     thread_context get_context();
     void set_context(thread_context &context);
 
+    void fork_init();
+
     addr_t get_stack();
     void set_stack(addr_t addr);
 

--- a/include/proc/thread.h
+++ b/include/proc/thread.h
@@ -95,6 +95,7 @@ void encode_tcontext(struct interrupt_context *ctx,
 void decode_tcontext(struct interrupt_context *ctx,
                      struct thread_context *thread_ctx);
 
-thread *create_kernel_thread(process *p, void (*entry_point)());
+thread *create_kernel_thread(process *p, void (*entry_point)(void *),
+                             void *data);
 
 void load_registers(struct thread_context &tcontext);

--- a/include/proc/thread.h
+++ b/include/proc/thread.h
@@ -17,6 +17,10 @@ enum class thread_state {
     RUNNING,
 };
 
+enum class thread_flag : int {
+    RESCHEDULE = 0,
+};
+
 class thread
 {
 public:
@@ -26,6 +30,9 @@ public:
 
     thread_state get_state();
     void set_state(thread_state state);
+
+    bool get_flag(thread_flag flag);
+    void set_flag(thread_flag flag, bool value);
 
     // For scheduler use
     void switch_thread(thread *next);
@@ -62,6 +69,7 @@ public:
 private:
     tid_t tid;
     thread_state state;
+    bool flags[1];
     process *parent;
 
     struct {

--- a/include/proc/thread.h
+++ b/include/proc/thread.h
@@ -79,6 +79,8 @@ private:
         addr_t kernel_stack;
     } tcb;
 
+    addr_t kernel_stack_base;
+
     // Signals
     size_t signal_count;
     bool signal_required;

--- a/include/proc/thread.h
+++ b/include/proc/thread.h
@@ -77,9 +77,8 @@ private:
     struct {
         struct thread_context tcontext; // Thread execution state
         addr_t kernel_stack;
+        addr_t kernel_stack_base;
     } tcb;
-
-    addr_t kernel_stack_base;
 
     // Signals
     size_t signal_count;

--- a/include/proc/thread.h
+++ b/include/proc/thread.h
@@ -87,7 +87,6 @@ void encode_tcontext(struct interrupt_context *ctx,
 void decode_tcontext(struct interrupt_context *ctx,
                      struct thread_context *thread_ctx);
 
-thread *create_kernel_thread(process *p, void (*entry_point)(void *),
-                             void *data);
+thread *create_kernel_thread(process *p, void (*entry_point)());
 
 void load_registers(struct thread_context &tcontext);

--- a/include/proc/thread.h
+++ b/include/proc/thread.h
@@ -27,8 +27,14 @@ public:
     thread_state get_state();
     void set_state(thread_state state);
 
+    // For scheduler use
+    void switch_thread(thread *next);
+
     thread_context get_context();
     void set_context(thread_context &context);
+
+    addr_t get_stack();
+    void set_stack(addr_t addr);
 
     tid_t get_tid();
     process *get_process();

--- a/include/proc/wq.h
+++ b/include/proc/wq.h
@@ -32,8 +32,8 @@ public:
      * However, if you want to wait on multiple wait_queues (e.g. poll), use
      * insert to register this thread with the wait_queue.
      *
-     * Then, you will manually need to schedule away (by calling yield()) and
-     * checking for the wake reason
+     * Then, you will manually need to schedule away (by calling switch_next())
+     * and checking for the wake reason
      */
     int wait(int flags);
     bool insert(int flags);

--- a/kernel/kmain.cc
+++ b/kernel/kmain.cc
@@ -18,23 +18,8 @@
 
 namespace
 {
-long long counter = 0;
-
-void worker()
+void init_stage2(void*)
 {
-    for (;;) {
-        log::printk(log::log_level::INFO, "Hello again, %d\n",
-                    scheduler::get_current_thread()->get_tid());
-    }
-}
-
-void init_stage2()
-{
-    for (;;) {
-        process* initp = scheduler::get_current_process();
-        thread* stage2 = create_kernel_thread(initp, worker);
-        scheduler::insert(stage2);
-    }
     process* parent = scheduler::get_current_process();
     libcxx::intrusive_ptr<filesystem::descriptor> root = parent->get_root();
     auto [err, init] = root->open("/sbin/init", O_RDONLY, 0);
@@ -64,7 +49,7 @@ void init_stage2()
 void init_stage1()
 {
     process* initp = scheduler::get_current_process()->fork();
-    thread* stage2 = create_kernel_thread(initp, init_stage2);
+    thread* stage2 = create_kernel_thread(initp, init_stage2, nullptr);
     scheduler::late_init();
     scheduler::insert(stage2);
     scheduler::get_current_process()->wait(-1, nullptr, 0);

--- a/kernel/time/time.cc
+++ b/kernel/time/time.cc
@@ -77,7 +77,8 @@ void tick(struct interrupt_context* ctx)
 {
     update();
     if (scheduler::online()) {
-        scheduler::switch_next(ctx);
+        scheduler::get_current_thread()->set_flag(thread_flag::RESCHEDULE,
+                                                  true);
     }
 }
 

--- a/mm/buddy.cc
+++ b/mm/buddy.cc
@@ -46,7 +46,7 @@ buddy::~buddy()
 addr_t buddy::__alloc(unsigned order)
 {
     if (order > this->max_order)
-        kernel::panic("OOM");
+        kernel::panic("OOM\n");
     if (this->orders[order].free_stack->empty()) {
         addr_t a = this->__alloc(order + 1);
         this->orders[order].free_stack->push(a);

--- a/proc/sched.cc
+++ b/proc/sched.cc
@@ -21,7 +21,7 @@ thread* kidle           = nullptr;
 bool _online = false;
 } // namespace
 
-void idle(void*)
+void idle()
 {
     while (1) {
         // TODO: Get rid of hlt
@@ -124,7 +124,7 @@ void init()
 
 void late_init()
 {
-    kidle = create_kernel_thread(kernel_process, idle, nullptr);
+    kidle = create_kernel_thread(kernel_process, idle);
 }
 
 process* get_current_process()

--- a/proc/sched.cc
+++ b/proc/sched.cc
@@ -63,10 +63,8 @@ thread* next()
     return next;
 }
 
-void switch_context(struct interrupt_context* ctx, thread* current,
-                    thread* next)
+void switch_context(thread* current, thread* next)
 {
-    current->save_state(ctx);
     if (current) {
         if (current->get_process()->get_address_space() !=
             next->get_process()->get_address_space()) {
@@ -77,26 +75,25 @@ void switch_context(struct interrupt_context* ctx, thread* current,
         memory::virt::set_address_space_root(
             next->get_process()->get_address_space());
     }
-    next->load_state(ctx);
 }
 
-void switch_next(struct interrupt_context* ctx)
+void switch_next()
 {
     thread* old         = current_thread;
     thread* next_thread = next();
-    switch_context(ctx, current_thread, next_thread);
+    switch_context(current_thread, next_thread);
     current_thread = next_thread;
     old->switch_thread(next_thread);
-    if (scheduler::online()) {
-        if (scheduler::get_current_thread()->is_signal_pending()) {
-            scheduler::get_current_thread()->handle_signal(ctx);
-        }
-    }
+    // if (scheduler::online()) {
+    //     if (scheduler::get_current_thread()->is_signal_pending()) {
+    //         scheduler::get_current_thread()->handle_signal(ctx);
+    //     }
+    // }
 }
 
 void yield_switch(int, void*, struct interrupt_context* ctx)
 {
-    switch_next(ctx);
+    switch_next();
 }
 
 interrupt::handler yield_handler(yield_switch, "yield", &yield_handler);

--- a/proc/sched.cc
+++ b/proc/sched.cc
@@ -21,7 +21,7 @@ thread* kidle           = nullptr;
 bool _online = false;
 } // namespace
 
-void idle()
+void idle(void*)
 {
     while (1) {
         // TODO: Get rid of hlt
@@ -121,7 +121,7 @@ void init()
 
 void late_init()
 {
-    kidle = create_kernel_thread(kernel_process, idle);
+    kidle = create_kernel_thread(kernel_process, idle, nullptr);
 }
 
 process* get_current_process()

--- a/proc/sched.cc
+++ b/proc/sched.cc
@@ -81,6 +81,9 @@ void switch_next()
 {
     thread* old         = current_thread;
     thread* next_thread = next();
+    if (next_thread == old) {
+        return;
+    }
     switch_context(current_thread, next_thread);
     current_thread = next_thread;
     old->switch_thread(next_thread);

--- a/proc/sched.cc
+++ b/proc/sched.cc
@@ -91,18 +91,15 @@ void switch_next()
     // }
 }
 
-void yield_switch(int, void*, struct interrupt_context* ctx)
+void yield()
 {
     switch_next();
 }
-
-interrupt::handler yield_handler(yield_switch, "yield", &yield_handler);
 
 void init()
 {
     // Print a message in case something goes wrong when initializing
     log::printk(log::log_level::INFO, "Initializing scheduler...\n");
-    interrupt::register_handler(0x81, yield_handler);
     kernel_process = new process(nullptr);
     kernel_process->set_address_space(memory::virt::get_address_space_root());
     // TODO: Move this to architecture specific

--- a/proc/sched.cc
+++ b/proc/sched.cc
@@ -84,11 +84,6 @@ void switch_next()
     old->switch_thread(next_thread);
 }
 
-void yield()
-{
-    switch_next();
-}
-
 void init()
 {
     // Print a message in case something goes wrong when initializing

--- a/proc/sched.cc
+++ b/proc/sched.cc
@@ -82,9 +82,11 @@ void switch_context(struct interrupt_context* ctx, thread* current,
 
 void switch_next(struct interrupt_context* ctx)
 {
+    thread* old         = current_thread;
     thread* next_thread = next();
     switch_context(ctx, current_thread, next_thread);
     current_thread = next_thread;
+    old->switch_thread(next_thread);
     if (scheduler::online()) {
         if (scheduler::get_current_thread()->is_signal_pending()) {
             scheduler::get_current_thread()->handle_signal(ctx);

--- a/proc/sched.cc
+++ b/proc/sched.cc
@@ -63,20 +63,6 @@ thread* next()
     return next;
 }
 
-void switch_context(thread* current, thread* next)
-{
-    if (current) {
-        if (current->get_process()->get_address_space() !=
-            next->get_process()->get_address_space()) {
-            memory::virt::set_address_space_root(
-                next->get_process()->get_address_space());
-        }
-    } else {
-        memory::virt::set_address_space_root(
-            next->get_process()->get_address_space());
-    }
-}
-
 void switch_next()
 {
     thread* old         = current_thread;
@@ -84,7 +70,16 @@ void switch_next()
     if (next_thread == old) {
         return;
     }
-    switch_context(current_thread, next_thread);
+    if (current_thread) {
+        if (current_thread->get_process()->get_address_space() !=
+            next_thread->get_process()->get_address_space()) {
+            memory::virt::set_address_space_root(
+                next_thread->get_process()->get_address_space());
+        }
+    } else {
+        memory::virt::set_address_space_root(
+            next_thread->get_process()->get_address_space());
+    }
     current_thread = next_thread;
     old->switch_thread(next_thread);
 }

--- a/proc/sched.cc
+++ b/proc/sched.cc
@@ -87,11 +87,6 @@ void switch_next()
     switch_context(current_thread, next_thread);
     current_thread = next_thread;
     old->switch_thread(next_thread);
-    // if (scheduler::online()) {
-    //     if (scheduler::get_current_thread()->is_signal_pending()) {
-    //         scheduler::get_current_thread()->handle_signal(ctx);
-    //     }
-    // }
 }
 
 void yield()

--- a/proc/syscall.cc
+++ b/proc/syscall.cc
@@ -184,6 +184,7 @@ static long sys_fork()
     // Child process gets 0 returned from fork
     ctx.rax = 0;
     child_thread->set_context(ctx);
+    child_thread->fork_init();
     scheduler::insert(child_thread);
     return child->get_pid();
 }

--- a/proc/thread.cc
+++ b/proc/thread.cc
@@ -68,5 +68,5 @@ void thread::exit(bool is_signal, int val)
     // TODO: We need to clean up!
     scheduler::remove(this);
     this->parent->thread_exit(this, is_signal, val);
-    scheduler::yield();
+    scheduler::switch_next();
 }

--- a/proc/thread.cc
+++ b/proc/thread.cc
@@ -5,10 +5,10 @@
 
 thread::thread(process* p, tid_t tid)
 {
-    parent             = p;
-    this->tid          = tid;
-    this->signal_count = 0;
-    this->tcb.kernel_stack =
+    parent                  = p;
+    this->tid               = tid;
+    this->signal_count      = 0;
+    this->kernel_stack_base = this->tcb.kernel_stack =
         reinterpret_cast<addr_t>(new uint8_t[0xF000] + 0xF000) & ~15UL;
     for (int i = 0; i < 1; i++) {
         this->flags[i] = false;

--- a/proc/thread.cc
+++ b/proc/thread.cc
@@ -5,10 +5,10 @@
 
 thread::thread(process* p, tid_t tid)
 {
-    parent                  = p;
-    this->tid               = tid;
-    this->signal_count      = 0;
-    this->kernel_stack_base = this->tcb.kernel_stack =
+    parent                      = p;
+    this->tid                   = tid;
+    this->signal_count          = 0;
+    this->tcb.kernel_stack_base = this->tcb.kernel_stack =
         reinterpret_cast<addr_t>(new uint8_t[0xF000] + 0xF000) & ~15UL;
     for (int i = 0; i < 1; i++) {
         this->flags[i] = false;

--- a/proc/thread.cc
+++ b/proc/thread.cc
@@ -10,6 +10,9 @@ thread::thread(process* p, tid_t tid)
     this->signal_count = 0;
     this->tcb.kernel_stack =
         reinterpret_cast<addr_t>(new uint8_t[0xF000] + 0xF000) & ~15UL;
+    for (int i = 0; i < 1; i++) {
+        this->flags[i] = false;
+    }
     signal::sigemptyset(&this->signal_mask);
     signal::sigemptyset(&this->signal_pending);
 }
@@ -31,6 +34,16 @@ process* thread::get_process()
 thread_state thread::get_state()
 {
     return this->state;
+}
+
+bool thread::get_flag(thread_flag flag)
+{
+    return this->flags[static_cast<int>(flag)];
+}
+
+void thread::set_flag(thread_flag flag, bool value)
+{
+    this->flags[static_cast<int>(flag)] = value;
 }
 
 void thread::set_state(thread_state state)

--- a/proc/wq.cc
+++ b/proc/wq.cc
@@ -12,7 +12,7 @@ int wait_queue::wait(int flags)
                      ? thread_state::SLEEPING_INTERRUPTIBLE
                      : thread_state::SLEEPING_UNINTERRUPTIBLE);
     scheduler::remove(t);
-    scheduler::yield();
+    scheduler::switch_next();
     int ret = 0;
     // Check if a signal is pending
     if (!node.normal_wake) {


### PR DESCRIPTION
This PR updates the task switching code to switch tasks using stack pointers instead of relying on interrupt contexts.

This allows us to remove the yield interrupt vector which is ugly for a variety of reasons. Furthermore, task switching between kernel tasks is a lot cheaper since we only need to save certain registers now instead of saving all task registers.

Resolves #18.